### PR TITLE
Add type information to fix HssMatrix{T} when T is not a Float64

### DIFF
--- a/src/compression.jl
+++ b/src/compression.jl
@@ -321,8 +321,8 @@ function randcompress_adaptive(A::AbstractMatOrLinOp{T}, rcl::ClusterTree, ccl::
   # compute initial sampling
   k = kest; r = opts.noversampling; bs = opts.stepsize
   #bs = Integer(ceil(n*0.01)) # this should probably be better estimated
-  Ωcol = randn(n, k+r)
-  Ωrow = randn(m, k+r)
+  Ωcol = randn(eltype(A),n, k+r)
+  Ωrow = randn(eltype(A),m, k+r)
   Scol = A*Ωcol # this should invoke the magic of the linearoperator.jl type
   Srow = A'*Ωrow
   failed = true
@@ -331,8 +331,8 @@ function randcompress_adaptive(A::AbstractMatOrLinOp{T}, rcl::ClusterTree, ccl::
     # TODO: In further versions we might want to re-use the information gained during previous attempts
     hssA, _, _, _, _, _, _, _, _  = _randcompress!(hssA, A, Scol, Srow, Ωcol, Ωrow, 0, 0, opts.atol, opts.rtol; rootnode=true)
 
-    Ωcol_test = randn(n, bs)
-    Ωrow_test = randn(m, bs)
+    Ωcol_test = randn(eltype(A),n, bs)
+    Ωrow_test = randn(eltype(A),m, bs)
     Scol_test = A*Ωcol_test
     Srow_test = A'*Ωrow_test
 

--- a/src/compression.jl
+++ b/src/compression.jl
@@ -321,8 +321,8 @@ function randcompress_adaptive(A::AbstractMatOrLinOp{T}, rcl::ClusterTree, ccl::
   # compute initial sampling
   k = kest; r = opts.noversampling; bs = opts.stepsize
   #bs = Integer(ceil(n*0.01)) # this should probably be better estimated
-  Ωcol = randn(eltype(A),n, k+r)
-  Ωrow = randn(eltype(A),m, k+r)
+  Ωcol = randn(T, n, k+r)
+  Ωrow = randn(T, m, k+r)
   Scol = A*Ωcol # this should invoke the magic of the linearoperator.jl type
   Srow = A'*Ωrow
   failed = true
@@ -331,8 +331,8 @@ function randcompress_adaptive(A::AbstractMatOrLinOp{T}, rcl::ClusterTree, ccl::
     # TODO: In further versions we might want to re-use the information gained during previous attempts
     hssA, _, _, _, _, _, _, _, _  = _randcompress!(hssA, A, Scol, Srow, Ωcol, Ωrow, 0, 0, opts.atol, opts.rtol; rootnode=true)
 
-    Ωcol_test = randn(eltype(A),n, bs)
-    Ωrow_test = randn(eltype(A),m, bs)
+    Ωcol_test = randn(T, n, bs)
+    Ωrow_test = randn(T, m, bs)
     Scol_test = A*Ωcol_test
     Srow_test = A'*Ωrow_test
 

--- a/src/generators.jl
+++ b/src/generators.jl
@@ -35,7 +35,7 @@ end
 # recursive function for getting just the desired index of colmn/row generators
 function _getindex_colgenerator(hssA::HssMatrix, i::Int)
   if isleaf(hssA)
-    return hssA.U[i,:]'
+    return hssA.U[i,:] |> transpose
   else
     m1 = hssA.sz1[1]
     if i <= m1
@@ -47,7 +47,7 @@ function _getindex_colgenerator(hssA::HssMatrix, i::Int)
 end
 function _getindex_rowgenerator(hssA::HssMatrix, j::Int)
   if isleaf(hssA)
-    hssA.V[j,:]'
+    hssA.V[j,:] |> transpose
   else
     n1 = hssA.sz1[2]
     if j <= n1

--- a/src/hssmatrix.jl
+++ b/src/hssmatrix.jl
@@ -138,13 +138,13 @@ function _getidx(hssA::HssMatrix, i::Int, j::Int)
       else
         U1 = _getindex_colgenerator(hssA.A11, i)
         V2 = _getindex_rowgenerator(hssA.A22, j-n1)
-        return dot(U1*hssA.B12, V2)
+        return U1*hssA.B12*V2'
       end
     else
       if j <= n1
         U2 = _getindex_colgenerator(hssA.A22, i-m1)
         V1 = _getindex_rowgenerator(hssA.A11, j)
-        return dot(U2*hssA.B21, V1)
+        return U2*hssA.B21*V1'
       else
         return _getidx(hssA.A22, i-m1, j-n1)
       end

--- a/src/matmul.jl
+++ b/src/matmul.jl
@@ -103,12 +103,12 @@ function _matmatdown!(hssA::HssMatrix{T}, hssB::HssMatrix{T}, Z::BinaryNode{Matr
     # evaluate cross terms
     F1 = hssA.B12 * Z.right.data * hssB.B21 + hssA.R1 * F * hssB.W1'
     F2 = hssA.B21 * Z.left.data * hssB.B12 + hssA.R2 * F * hssB.W2'
-    B12 = [hssA.B12 hssA.R1 * F * hssB.W2'; zeros(size(hssB.B12, 1), size(hssA.B12,2)) hssB.B12]
-    B21 = [hssA.B21 hssA.R2 * F * hssB.W1'; zeros(size(hssB.B21, 1), size(hssA.B21,2)) hssB.B21]
-    R1 = [hssA.R1 hssA.B12 * Z.right.data * hssB.R2; zeros(size(hssB.R1,1), size(hssA.R1,2)) hssB.R1];
-    W1 = [hssA.W1 zeros(size(hssA.W1,1), size(hssB.W1,2)); hssB.B21' * Z.right.data' * hssA.W2 hssB.W1];
-    R2 = [hssA.R2 hssA.B21 * Z.left.data * hssB.R1; zeros(size(hssB.R2,1), size(hssA.R2,2)) hssB.R2];
-    W2 = [hssA.W2 zeros(size(hssA.W2,1), size(hssB.W2,2)); hssB.B12' * Z.left.data' * hssA.W1 hssB.W2];
+    B12 = [hssA.B12 hssA.R1 * F * hssB.W2'; zeros(T,size(hssB.B12, 1), size(hssA.B12,2)) hssB.B12]
+    B21 = [hssA.B21 hssA.R2 * F * hssB.W1'; zeros(T,size(hssB.B21, 1), size(hssA.B21,2)) hssB.B21]
+    R1 = [hssA.R1 hssA.B12 * Z.right.data * hssB.R2; zeros(T,size(hssB.R1,1), size(hssA.R1,2)) hssB.R1];
+    W1 = [hssA.W1 zeros(T,size(hssA.W1,1), size(hssB.W1,2)); hssB.B21' * Z.right.data' * hssA.W2 hssB.W1];
+    R2 = [hssA.R2 hssA.B21 * Z.left.data * hssB.R1; zeros(T,size(hssB.R2,1), size(hssA.R2,2)) hssB.R2];
+    W2 = [hssA.W2 zeros(T,size(hssA.W2,1), size(hssB.W2,2)); hssB.B12' * Z.left.data' * hssA.W1 hssB.W2];
     A11 = _matmatdown!(hssA.A11, hssB.A11, Z.left, F1)
     A22 = _matmatdown!(hssA.A22, hssB.A22, Z.right, F2)
     return HssMatrix(A11, A22, B12, B21, R1, W1, R2, W2, false)

--- a/src/ulvdivide.jl
+++ b/src/ulvdivide.jl
@@ -121,8 +121,8 @@ function _utransforms_kernel!(hssA::HssMatrix, Q::BinaryNode)
 end
 function _ltransforms_kernel!(hssA::HssMatrix, Q::BinaryNode)
   nk = size(Q.data,1)
-  hssA.D[1:nk, :] = trsm('L', 'L', 'N', 'N', 1., Q.data, hssA.D[1:nk,:])
-  hssA.U[1:nk, :] = trsm('L', 'L', 'N', 'N', 1., Q.data, hssA.U[1:nk,:])
+  hssA.D[1:nk, :] = trsm('L', 'L', 'N', 'N', eltype(hssA)(1), Q.data, hssA.D[1:nk,:])
+  hssA.U[1:nk, :] = trsm('L', 'L', 'N', 'N', eltype(hssA)(1), Q.data, hssA.U[1:nk,:])
   hssA.D[nk+1:end, :] .= eltype(hssA)(0)
   hssA.U[nk+1:end, :] .= eltype(hssA)(0)
   return hssA

--- a/src/ulvdivide.jl
+++ b/src/ulvdivide.jl
@@ -128,7 +128,8 @@ function _ltransforms_kernel!(hssA::HssMatrix, Q::BinaryNode)
   return hssA
 end
 function _vtransforms_kernel!(hssA::HssMatrix, Q::BinaryNode)
-  eltype(hssA) <: Complex ? adj = 'C' : adj = 'T'
+  eltype(hssA) <: Complex ? adj = 'C' : adj = 'T' 
+  if size(Q.data[1], 1) == 0 return hssA end
   hssA.D = ormlq!('L', adj, Q.data..., hssA.D)
   hssA.U = ormlq!('L', adj, Q.data..., hssA.U)
   return hssA

--- a/src/ulvfactor.jl
+++ b/src/ulvfactor.jl
@@ -11,7 +11,7 @@ function ulvfactsolve(hssA::HssMatrix{T}, b::Matrix{T}) where T
   if isleaf(hssA)
     return hssA.D\b
   else
-    z = zeros(eltype(hssA),size(hssA,2), size(b,2))
+    z = zeros(T, size(hssA,2), size(b,2))
     _, _, _, _, _, _, _, QV = _ulvfactsolve!(hssA, b, z, 0; rootnode=true)
     z = _ulvfactsolve_topdown!(QV, z)
     return z

--- a/src/ulvfactor.jl
+++ b/src/ulvfactor.jl
@@ -11,7 +11,7 @@ function ulvfactsolve(hssA::HssMatrix{T}, b::Matrix{T}) where T
   if isleaf(hssA)
     return hssA.D\b
   else
-    z = zeros(size(hssA,2), size(b,2))
+    z = zeros(eltype(hssA),size(hssA,2), size(b,2))
     _, _, _, _, _, _, _, QV = _ulvfactsolve!(hssA, b, z, 0; rootnode=true)
     z = _ulvfactsolve_topdown!(QV, z)
     return z
@@ -45,7 +45,7 @@ function _ulvreduce!(D::Matrix{T}, U::Matrix{T}, V::Matrix{T}, b::Matrix{T}) whe
     L1 = tril(lqf[1])
     L1 = L1[:,1:nk]
     L2 = ormlq!('R', adj, lqf..., D[end-k+1:end,:]) # update the bottom block of the diagonal block
-    zloc = trsm('L', 'L', 'N', 'N', 1., L1, b[ind,:])
+    zloc = trsm('L', 'L', 'N', 'N', T(1), L1, b[ind,:])
     b = b[cind, :] .- L2[:,1:nk] * zloc # remove contribution in the uncompressed parts
     V = ormlq!('L', 'N', lqf..., V) # compute the updated off-diagonal generators on the right
     u = V[ind,:]' * zloc # compute update vector to be passed on

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Test, LinearAlgebra, HssMatrices
 end
 
 @testset for T in [Float32, Float64, ComplexF32,ComplexF64]
+
     # generate Cauchy matrix
     K(x,y) = (x-y) > 0 ? 0.001/(x-y) : 2.
     A = [ T(K(x,y)) for x=-1:0.001:1, y=-1:0.001:1];
@@ -60,7 +61,7 @@ end
         @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
         hssA.A11 = prune_leaves!(hssA.A11)
         hssI.A11 = prune_leaves!(hssI.A11)
-        @test_skip norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
-        @test_skip norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
+        @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
+        @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
     end
 end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,5 @@
 using Test, LinearAlgebra, HssMatrices
 
-# generate Cauchy matrix
-K(x,y) = (x-y) > 0 ? 0.001/(x-y) : 2.
-A = [ K(x,y) for x=-1:0.001:1, y=-1:0.001:1];
-m, n = size(A)
-U = randn(n,3); V = randn(n,3)
-# "safety" factor
-c = 1000.0
-
 @testset "options" begin
     HssMatrices.setopts(atol=1e-6)
     @test HssOptions().atol == 1e-6
@@ -21,40 +13,54 @@ c = 1000.0
     @test HssOptions().stepsize == 10
 end
 
-rcl = bisection_cluster(1:m)
-ccl = bisection_cluster(1:n)
+@testset for T in [Float32, Float64, ComplexF32, ComplexF64]
+    # generate Cauchy matrix
+    K(x,y) = (x-y) > 0 ? 0.001/(x-y) : 2.
+    A = [ T(K(x,y)) for x=-1:0.001:1, y=-1:0.001:1];
+    m, n = size(A)
+    U = randn(T,n,3); V = randn(T,n,3)
+    # "safety" factor
+    c = 50.
+    # increase tolerance for Float32 and ComplexF32
+    tol = max(1E-6,50*eps(real(T)))
+    HssMatrices.setopts(atol=tol)
+    HssMatrices.setopts(rtol=tol)
 
-@testset "compression" begin
-    hssA = compress(A, rcl, ccl);
-    @test norm(A - full(hssA))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssA)) ≤ c*HssOptions().atol
-    hssB = randcompress_adaptive(A, rcl, ccl); rk = hssrank(hssB)
-    @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
-    hssB = recompress!(hssB)
-    @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
-    @test hssrank(hssB) ≤ rk
-    hssC = lowrank2hss(U, V, ccl, ccl)
-    @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*eps()
-    @test hssrank(hssC) == 3
-end;
+    rcl = bisection_cluster(1:m)
+    ccl = bisection_cluster(1:n)
 
-@testset "arithmetic" begin
-    hssA = compress(A, rcl, ccl);
-    hssC = lowrank2hss(U, V, ccl, ccl)
-    @test norm(A' - full(hssA'))/norm(A) ≤ c*HssOptions().rtol || norm(A' - full(hssA')) ≤ c*HssOptions().atol
-    x = randn(n, 5);
-    @test norm(A*x - hssA*x)/norm(A*x) ≤ c*HssOptions().rtol || norm(A*x - hssA*x) ≤ c*HssOptions().atol
-    @test norm(full(hssA*hssC) - (A*U)*V')/norm((A*U)*V') ≤ c*HssOptions().rtol || norm(A*x - hssA*x) ≤ c*HssOptions().atol
-    rhs = randn(n, 5); x = hssA\rhs; x0 = A\rhs;
-    @test norm(x0 - x)/norm(x0) ≤ c*HssOptions().rtol || norm(x0 - x) ≤ c*HssOptions().atol
-    Id(i,j) = Matrix{Float64}(i.*ones(length(j))' .== ones(length(i)).*j')
-    IdOp = LinearMap{Float64}(n, n, (y,_,x) -> x, (y,_,x) -> x, (i,j) -> Id(i,j))
-    hssI = randcompress(IdOp, ccl, ccl, 0)
-    @test norm(full(hssA*hssI) - full(hssA))/norm(full(hssA)) ≤ c*eps()
-    Ainv = inv(A)
-    @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
-    @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
-    hssA.A11 = prune_leaves!(hssA.A11)
-    hssI.A11 = prune_leaves!(hssI.A11)
-    @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
-    @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
-end
+    @testset "compression" begin
+        hssA = compress(A, rcl, ccl);
+        @test norm(A - full(hssA))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssA)) ≤ c*HssOptions().atol
+        hssB = randcompress_adaptive(A, rcl, ccl); rk = hssrank(hssB)
+        @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
+        hssB = recompress!(hssB)
+        @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
+        @test hssrank(hssB) ≤ rk
+        hssC = lowrank2hss(U, V, ccl, ccl)
+        @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*eps()
+        @test hssrank(hssC) == 3
+    end;
+
+    @testset "arithmetic" begin
+        hssA = compress(A, rcl, ccl);
+        hssC = lowrank2hss(U, V, ccl, ccl)
+        @test norm(A' - full(hssA'))/norm(A) ≤ c*HssOptions().rtol || norm(A' - full(hssA')) ≤ c*HssOptions().atol
+        x = randn(T, n, 5);
+        @test norm(A*x - hssA*x)/norm(A*x) ≤ c*HssOptions().rtol || norm(A*x - hssA*x) ≤ c*HssOptions().atol
+        @test norm(full(hssA*hssC) - (A*U)*V')/norm((A*U)*V') ≤ c*HssOptions().rtol || norm(A*x - hssA*x) ≤ c*HssOptions().atol
+        rhs = randn(T,n, 5); x = hssA\rhs; x0 = A\rhs;
+        @test norm(x0 - x)/norm(x0) ≤ c*HssOptions().rtol || norm(x0 - x) ≤ c*HssOptions().atol
+        Id(i,j) = Matrix{T}(i.*ones(length(j))' .== ones(length(i)).*j')
+        IdOp = LinearMap{T}(n, n, (y,_,x) -> x, (y,_,x) -> x, (i,j) -> Id(i,j))
+        hssI = randcompress(IdOp, ccl, ccl, 0)
+        @test norm(full(hssA*hssI) - full(hssA))/norm(full(hssA)) ≤ c*eps()
+        Ainv = inv(A)
+        @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
+        @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
+        hssA.A11 = prune_leaves!(hssA.A11)
+        hssI.A11 = prune_leaves!(hssI.A11)
+        @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
+        @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
+    end
+end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using Test, LinearAlgebra, HssMatrices
     @test HssOptions().stepsize == 10
 end
 
-@testset for T in [Float32, Float64, ComplexF32, ComplexF64]
+@testset for T in [Float32, Float64, ComplexF32,ComplexF64]
     # generate Cauchy matrix
     K(x,y) = (x-y) > 0 ? 0.001/(x-y) : 2.
     A = [ T(K(x,y)) for x=-1:0.001:1, y=-1:0.001:1];
@@ -38,7 +38,7 @@ end
         @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
         @test hssrank(hssB) ≤ rk
         hssC = lowrank2hss(U, V, ccl, ccl)
-        @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*eps()
+        @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*eps(real(T))
         @test hssrank(hssC) == 3
     end;
 
@@ -60,7 +60,7 @@ end
         @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
         hssA.A11 = prune_leaves!(hssA.A11)
         hssI.A11 = prune_leaves!(hssI.A11)
-        @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
-        @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
+        @test_skip norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
+        @test_skip norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol
     end
 end 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,9 +49,8 @@ end
     @testset "random access" begin
         I = rand(1:size(A,1), 10)
         J = rand(1:size(A,1), 10)
-        function testAccuracy(expected, result)
-            @test norm(expected - result)/norm(expected) ≤ c*HssOptions().rtol || norm(expected - result) ≤ c*HssOptions().atol
-        end
+        testAccuracy(expected, result) = @test norm(expected - result)/norm(expected) ≤ c*HssOptions().rtol || 
+            norm(expected - result) ≤ c*HssOptions().atol
         testAccuracy(A[I,J], compress(A, rcl, ccl)[I,J])
         testAccuracy(A[I,:], compress(A, rcl, ccl)[I,:])
         testAccuracy(A[:,J], compress(A, rcl, ccl)[:,J])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
     # "safety" factor
     c = 50.
     # increase tolerance for Float32 and ComplexF32
-    tol = max(1E-6,50*eps(real(T)))
+    tol = 1E-6
     HssMatrices.setopts(atol=tol)
     HssMatrices.setopts(rtol=tol)
 
@@ -39,7 +39,7 @@ end
         @test norm(A - full(hssB))/norm(A) ≤ c*HssOptions().rtol || norm(A - full(hssB)) ≤ c*HssOptions().atol
         @test hssrank(hssB) ≤ rk
         hssC = lowrank2hss(U, V, ccl, ccl)
-        @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*eps(real(T))
+        @test norm(U*V' - full(hssC))/norm(U*V') ≤ c*tol
         @test hssrank(hssC) == 3
     end;
 
@@ -55,7 +55,7 @@ end
         Id(i,j) = Matrix{T}(i.*ones(length(j))' .== ones(length(i)).*j')
         IdOp = LinearMap{T}(n, n, (y,_,x) -> x, (y,_,x) -> x, (i,j) -> Id(i,j))
         hssI = randcompress(IdOp, ccl, ccl, 0)
-        @test norm(full(hssA*hssI) - full(hssA))/norm(full(hssA)) ≤ c*eps()
+        @test norm(full(hssA*hssI) - full(hssA))/norm(full(hssA)) ≤ c*tol
         Ainv = inv(A)
         @test norm(Ainv - full(hssA\hssI))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssA\hssI)) ≤ c*HssOptions().atol
         @test norm(Ainv - full(hssI/hssA))/norm(Ainv) ≤ c*HssOptions().rtol || norm(Ainv - full(hssI/hssA)) ≤ c*HssOptions().atol


### PR DESCRIPTION
Several functions were generating errors when called with HssMatrix{T}
 where T was not a Float64. These include: \ , / and compress_adatative.

This commit solves this problem and adds a test for it.