### PR TITLE
Fixed complex linear solve (and some extra)

### DIFF
--- a/src/hssmatrix.jl
+++ b/src/hssmatrix.jl
@@ -231,7 +231,7 @@ for op in (:+,:-)
 end
 
 # matrix division involving HSS matrices
-\(hssA::HssMatrix, B::Matrix) = ulvfactsolve(hssA, B)
+\(hssA::HssMatrix, B::VecOrMat) = ulvfactsolve(hssA, B)
 \(hssA::HssMatrix, hssB::HssMatrix) = ldiv!(hssA, copy(hssB))
 /(A::Matrix, hssB::HssMatrix) = ulvfactsolve(hssB', collect(A'))'
 /(hssA::HssMatrix, hssB::HssMatrix) = rdiv!(copy(hssA), hssB)

--- a/src/ulvfactor.jl
+++ b/src/ulvfactor.jl
@@ -7,12 +7,12 @@
 # Written by Boris Bonev, Nov. 2020
 
 ## function for direct solution using the implicit ULV factorization
-function ulvfactsolve(hssA::HssMatrix{T}, b::Matrix{T}) where T
+function ulvfactsolve(hssA::HssMatrix{T}, b::VecOrMat{T}) where T
   if isleaf(hssA)
     return hssA.D\b
   else
-    z = zeros(size(hssA,2), size(b,2))
-    _, _, _, _, _, _, _, QV = _ulvfactsolve!(hssA, b, z, 0; rootnode=true)
+    z = zeros(eltype(hssA),size(hssA,2), size(b,2))
+    _, _, _, _, _, _, _, QV = _ulvfactsolve!(hssA, reshape(b,size(b,1),size(b,2)), z, 0; rootnode=true)
     z = _ulvfactsolve_topdown!(QV, z)
     return z
   end


### PR DESCRIPTION
Hey again Boris,
I played a little around with your code. 

Here are some very simple fixed so that:
1. You can solve linear systems with a `Vector` as a right-hand side
2. Solve complex linear systems.

I still believe there are some (very simple) improvements to be made (however, I currently do no have time to fix this):
 * Automatically promote to a common datatypes (so that you can multiply a complex `HssMatrix` with a real `Vector`).
 * Returning a `Vector` instead of a `Matrix` when solving a linear system with a `Vector` as its rhs.

Cheers,
Mikkel